### PR TITLE
delete 'quick creation option'

### DIFF
--- a/src/content/docs/advanced/tags-labels/labels-and-custom-fields.md
+++ b/src/content/docs/advanced/tags-labels/labels-and-custom-fields.md
@@ -3,7 +3,7 @@ title: Labels and Custom Fields
 description: Learn how to use labels and custom fields in Testomat.io to organize and categorize tests, suites, runs, plans, and steps. This guide covers creating and setting up labels with specific scope and visibility, as well as configuring custom fields with List, Number, and String types. It also explains how to assign labels in bulk, make them required by default, filter by them, and manage user permissions for enhanced project organization and security.
 type: article
 url: https://docs.testomat.io/advanced/tags-labels/labels-and-custom-fields
-head: 
+head:
   - tag: meta
     attrs:
       name: keywords
@@ -29,13 +29,12 @@ Before setting up Labels & Custom Fields we need to learn about **Scope** and **
 
 ![Testomatio - Setup Label](./images/Labels.png)
 
-**Visibility**  defines how a Label & Custom Field should be shown in UI. 
+**Visibility** defines how a Label & Custom Field should be shown in UI.
 
 - Filter visibility will show a Label or Custom Field in the Filter Bar, so you can sort your items quickly.
 - List visibility will show a Label or Custom Field in the tests tree, a list of runs, plans, or steps.
 
 ![Testomatio - Setup Label](./images/Visibility_Labels.png)
-
 
 Now it's time to set up your label!
 
@@ -45,37 +44,13 @@ Now it's time to set up your label!
 
 ![Testomatio - Setup Label](./images/Setup_Labels.png)
 
-You can also use **Quick create label** feature to create labels faster:
-
-1. Go to Steps
-2. Select Step
-3. Click Extra button.
-4. Click Labels.
-5. Type Label name in 'Quick create label' field.
-6. Click Create button.
-7. Select newly Created Label.
-
-![Testomatio - Quick Create Label](./images/Quick_create_label.gif)
-
-:::note
-
-**Quick create label** feature available only on Set Labels page for **Runs**, **Plans** and **Steps**.
-
-Labels created via **Quick Create Label** feature use default minimal settings and can be assigned only to the entity level where it was created. You can modify these settings later by navigating to **Settings -> Labels&Fields**.
-
-:::
-
-Example of default settings for Label, created via **Quick create label** feature on Step level:
-
-![Testomatio - Quick Create Label](./images/Quick_create_label_settings.png)
-
 ## How to Setup a Custom Field
 
 There are such Field Types in Custom Fields: List, Number, and String. Let's take a look at each type.
 
 ### Custom Field: List
 
-Custom Field with List type allows creating a list of your choice. You can put there any values to meet your testing needs. 
+Custom Field with List type allows creating a list of your choice. You can put there any values to meet your testing needs.
 
 1. Select a List type of Custom Field.
 2. Add a new item per line.
@@ -117,7 +92,7 @@ Custom Field with List type allows creating a list of your choice. You can put t
 
 ![Testomatio - Assign Label & Custom Field](./images/Set_Labels.gif)
 
-OR: 
+OR:
 
 1. Open a Suite/ Test.
 2. Click Set Labels button the title name.
@@ -149,12 +124,12 @@ To edit Labels & Custom fields or add a new one click **Manage labels** button d
 
 ## How to Set Up Labels and Custom Fields as Required
 
-If you want to have some Labels and Custom Fields as required by default when creating Test Cases or Suites, create a Template with those labels and set it up as the default:
+If you want to have some **Custom Fields** as required by default when creating Test Cases or Suites, create a Template with those **Custom Fields** and set it up as the default:
 
 1. Go to Settings -> Templates.
 2. Open an existing Template or create a new one.
-3. Enable Default option. 
-4. Select Labels & Custom Fields you want to make required.
+3. Enable Default option.
+4. Select **Custom Fields** you want to make required.
 5. Click Update button.
 
 ![Testomatio - Required Labels](./images/Required_Labels.png)
@@ -183,7 +158,7 @@ In case you need to filter your test cases by a few Labels and Custom Fields wit
 
 ## Multiple Values for Custom Fields
 
-There might be cases where you need to assign the same label with different values to the same test case or suite. 
+There might be cases where you need to assign the same label with different values to the same test case or suite.
 
 To address this, Testomat.io enhanced the flexibility of Custom Fields by allowing multiple values to be assigned to test cases, suites, steps, etc.
 
@@ -205,7 +180,7 @@ Testomat.io also allows you to filter your test cases by one or a few Custom Fie
 
 To manage Labels and Custom Fields at the Project level, Testomat.io introduces 'Labels Permission' feature, which allows you to have a better control over metadata, maintain consistency, and prevent unauthorized modifications of Labels and Custom Fields.
 
-By default, this permission is disabled, allowing all users to create, edit, or delete Labels and Custom Fields. However, if the **Labels Permission** is enabled, only users with the **Owner** or **Manager** roles can create, edit, or delete Labels and Custom Fields. Team members with lower access levels can still use existing Labels and Custom Fields but will not be able to alter them. 
+By default, this permission is disabled, allowing all users to create, edit, or delete Labels and Custom Fields. However, if the **Labels Permission** is enabled, only users with the **Owner** or **Manager** roles can create, edit, or delete Labels and Custom Fields. Team members with lower access levels can still use existing Labels and Custom Fields but will not be able to alter them.
 
 This feature improves project organization, enhances security, and streamlines collaboration by ensuring structured and standardized test management.
 


### PR DESCRIPTION
Removed a section with quick creation (it's no loger exist)

https://docs.testomat.io/advanced/tags-labels/labels-and-custom-fields/#how-to-setup-a-label